### PR TITLE
Add sheet music PDF links from Tobis Notenarchiv (CC BY-NC 4.0)

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,16 @@ td:first-child {
     width: 48px;
 }
 
+td:first-child a {
+    color: inherit;
+    text-decoration: none;
+    opacity: 0.75;
+}
+
+td:first-child a:hover {
+    opacity: 1;
+}
+
 tbody tr[data-nr]:hover td {
     background: #fdf5ec;
 }
@@ -252,7 +262,7 @@ audio {
 
 <!-- 7 -->
 <tr data-nr="7">
-<td>7</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_03.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 7 – Notenblatt (PDF, tobis-notenarchiv.de)">7</a></td>
 <td><audio controls preload="none" src="audio/nr7-S.m4a" aria-label="Nr. 7 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr7-A.m4a" aria-label="Nr. 7 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr7-T.m4a" aria-label="Nr. 7 – Tenor"></audio></td>
@@ -261,7 +271,7 @@ audio {
 
 <!-- 9 -->
 <tr data-nr="9">
-<td>9</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_05.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 9 – Notenblatt (PDF, tobis-notenarchiv.de)">9</a></td>
 <td><audio controls preload="none" src="audio/nr9-S.m4a" aria-label="Nr. 9 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr9-A.m4a" aria-label="Nr. 9 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr9-T.m4a" aria-label="Nr. 9 – Tenor"></audio></td>
@@ -270,7 +280,7 @@ audio {
 
 <!-- 15 -->
 <tr data-nr="15">
-<td>15</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_11.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 15 – Notenblatt (PDF, tobis-notenarchiv.de)">15</a></td>
 <td><audio controls preload="none" src="audio/nr15-S.m4a" aria-label="Nr. 15 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr15-A.m4a" aria-label="Nr. 15 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr15-T.m4a" aria-label="Nr. 15 – Tenor"></audio></td>
@@ -279,7 +289,7 @@ audio {
 
 <!-- 20 -->
 <tr data-nr="20">
-<td>20</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_14.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 20 – Notenblatt (PDF, tobis-notenarchiv.de)">20</a></td>
 <td><audio controls preload="none" src="audio/nr20-S.m4a" aria-label="Nr. 20 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr20-A.m4a" aria-label="Nr. 20 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr20-T.m4a" aria-label="Nr. 20 – Tenor"></audio></td>
@@ -288,7 +298,7 @@ audio {
 
 <!-- 21 -->
 <tr data-nr="21">
-<td>21</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_15.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 21 – Notenblatt (PDF, tobis-notenarchiv.de)">21</a></td>
 <td><audio controls preload="none" src="audio/nr21-S.m4a" aria-label="Nr. 21 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr21-A.m4a" aria-label="Nr. 21 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr21-T.m4a" aria-label="Nr. 21 – Tenor"></audio></td>
@@ -297,7 +307,7 @@ audio {
 
 <!-- 27 -->
 <tr data-nr="27">
-<td>27</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_17.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 27 – Notenblatt (PDF, tobis-notenarchiv.de)">27</a></td>
 <td><audio controls preload="none" src="audio/nr27-S.m4a" aria-label="Nr. 27 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr27-A.m4a" aria-label="Nr. 27 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr27-T.m4a" aria-label="Nr. 27 – Tenor"></audio></td>
@@ -306,7 +316,7 @@ audio {
 
 <!-- 40 -->
 <tr data-nr="40">
-<td>40</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_22.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 40 – Notenblatt (PDF, tobis-notenarchiv.de)">40</a></td>
 <td><audio controls preload="none" src="audio/nr40-S.m4a" aria-label="Nr. 40 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr40-A.m4a" aria-label="Nr. 40 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr40-T.m4a" aria-label="Nr. 40 – Tenor"></audio></td>
@@ -315,7 +325,7 @@ audio {
 
 <!-- 52 -->
 <tr data-nr="52">
-<td>52</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_26.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 52 – Notenblatt (PDF, tobis-notenarchiv.de)">52</a></td>
 <td><audio controls preload="none" src="audio/nr52-S.m4a" aria-label="Nr. 52 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr52-A.m4a" aria-label="Nr. 52 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr52-T.m4a" aria-label="Nr. 52 – Tenor"></audio></td>
@@ -324,7 +334,7 @@ audio {
 
 <!-- 56 -->
 <tr data-nr="56">
-<td>56</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_28.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 56 – Notenblatt (PDF, tobis-notenarchiv.de)">56</a></td>
 <td><audio controls preload="none" src="audio/nr56-S.m4a" aria-label="Nr. 56 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr56-A.m4a" aria-label="Nr. 56 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr56-T.m4a" aria-label="Nr. 56 – Tenor"></audio></td>
@@ -333,7 +343,7 @@ audio {
 
 <!-- 65 -->
 <tr data-nr="65">
-<td>65</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_37.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 65 – Notenblatt (PDF, tobis-notenarchiv.de)">65</a></td>
 <td><audio controls preload="none" src="audio/nr65-S.m4a" aria-label="Nr. 65 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr65-A.m4a" aria-label="Nr. 65 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr65-T.m4a" aria-label="Nr. 65 – Tenor"></audio></td>
@@ -342,7 +352,7 @@ audio {
 
 <!-- 68 -->
 <tr data-nr="68">
-<td>68</td>
+<td><a href="https://www.tobis-notenarchiv.de/bach/05-Passionen/02-Johannespassion/BWV_0245_40.pdf" target="_blank" rel="noopener noreferrer" aria-label="Nr. 68 – Notenblatt (PDF, tobis-notenarchiv.de)">68</a></td>
 <td><audio controls preload="none" src="audio/nr68-S.m4a" aria-label="Nr. 68 – Sopran"></audio></td>
 <td><audio controls preload="none" src="audio/nr68-A.m4a" aria-label="Nr. 68 – Alt"></audio></td>
 <td><audio controls preload="none" src="audio/nr68-T.m4a" aria-label="Nr. 68 – Tenor"></audio></td>
@@ -357,6 +367,7 @@ audio {
     <p>Die Johannespassion BWV 245 wurde am <strong>7. April 1724</strong> in der Thomaskirche Leipzig uraufgeführt — Bachs erstes großes Passionswerk als Thomaskantor.</p>
     <p>Das Werk gliedert sich in Rezitative, Arien, Chöre und Choräle. <strong>Nr. 1 ist der Eingangschor</strong> („Herr, unser Herrscher“); der erste Choral erscheint erst als Nr. 7 („O große Lieb“). Die Lücken in der Nummerierung — also fehlende Nummern zwischen den Chorälen — sind keine Auslassungen, sondern Rezitative, Arien und Chöre.</p>
     <p>Die Nummern folgen der <strong>Bach-Gesellschaft-Ausgabe (BG)</strong>, der historischen Gesamtausgabe, und stimmen mit den meisten gedruckten Partituren überein.</p>
+    <p>Notenblätter: <a href="https://tobis-notenarchiv.de/wp/en/bach-archive/vocal-works/passions/st-john-passion/" target="_blank" rel="noopener noreferrer">Tobis Notenarchiv</a>, lizenziert unter <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener noreferrer">CC BY-NC 4.0</a>.</p>
 </footer>
 
 <script src="lyrics.js"></script>


### PR DESCRIPTION
Each chorale number in the Nr. column now links to its individual score PDF on tobis-notenarchiv.de (opens in new tab). Attribution added to footer per CC BY-NC 4.0 license. Numbers styled with inherited color and subtle opacity to fit the existing design.

Closes #4