### PR TITLE
Improve screen reader readability of autoplay hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,7 @@ function updateVoiceUI() {
     });
     const autoplayOn = autoplayCheckbox.checked;
     voicePrefHint.textContent = preferredVoice && autoplayOn
-        ? "→ Beim Öffnen des Notenblatts startet " + VOICE_LABEL[preferredVoice] + " nach 3 s"
+        ? "→ Beim Öffnen des Notenblatts startet " + VOICE_LABEL[preferredVoice] + " nach 3\u00a0Sekunden"
         : "";
 }
 


### PR DESCRIPTION
## Summary

- Spell out `3 Sekunden` instead of `3 s` so assistive technologies read the unit naturally
- Use a non-breaking space (`\u00a0`) between number and unit to prevent awkward line breaks

## Test plan

- [ ] Toggle a voice preference and enable Autoplay — hint reads "nach 3 Sekunden" aloud with a screen reader (VoiceOver/NVDA)
- [ ] Verify the hint text looks correct visually in desktop and mobile layouts